### PR TITLE
Update env variables

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
-[context.staging]
+[context.staging.environment]
     WP_GQL_API = "https://orlistg.wpengine.com/graphql"


### PR DESCRIPTION
Updating the WP_GQL_API so that it pulls from orlistg.wpengine.com and not orlidev.wpengine.com